### PR TITLE
[Fixes #1] Show an error when ~/.slither_templates can't be parsed

### DIFF
--- a/src/slither-addset.ts
+++ b/src/slither-addset.ts
@@ -127,8 +127,16 @@ interface Answers extends Testset {
 
 let templatesPrm =
 	fs.readFile(path.join(process.env["HOME"], ".slither_templates"))
-		.then((templatesBuf) => JSON.parse(templatesBuf.toString()))
-		.catch((err) => DEFAULT_TEMPLATES);
+		.then((templatesBuf) => {
+			try {
+				return JSON.parse(templatesBuf.toString());
+			} catch (err) {
+				// ~/.slither_templates was not valid json
+				console.error(`${BOLD}${RED}Failed to parse ~/.slither_templates.  Using default templates.${CLEAR}`);
+				return DEFAULT_TEMPLATES;
+			}
+		})
+		.catch((err) => DEFAULT_TEMPLATES); // ~/.slither_templates was not found
 
 Promise.all([fs.readFile(".slither/config.json"), templatesPrm])
 	.catch((err) => {


### PR DESCRIPTION
@Strikeskids - does this fix the problem appropriately?  I tested a little bit and it seems to work.